### PR TITLE
fix for wl_cfg80211_mgmt_tx kernel panic issue

### DIFF
--- a/drivers/net/wireless/bcmdhd/wl_cfg80211.c
+++ b/drivers/net/wireless/bcmdhd/wl_cfg80211.c
@@ -6816,7 +6816,13 @@ wl_cfg80211_mgmt_tx(struct wiphy *wiphy, bcm_struct_cfgdev *cfgdev,
 		WL_ERR(("Driver only allows MGMT packet type\n"));
 		goto exit;
 	}
-
+	
+	if (len >  (action_frame->len + DOT11_MGMT_HDR_LEN)) {
+  			WL_ERR(("invalid action frame length:%zu\n"));
+                        return BCME_BADARG;
+                        goto exit;
+	}
+	
 	af_params = (wl_af_params_t *) kzalloc(WL_WIFI_AF_PARAMS_SIZE, GFP_KERNEL);
 
 	if (af_params == NULL)


### PR DESCRIPTION
The lower level nl80211 code in cfg80211 ensures that "len" is between 25 and NL80211_ATTR_FRAME (2304).
Without this bcmdhd crash randomly and makes the phone reboot.
 just followed the same logic as brcmfmac fix for the same issue .
The phone is up and running without a reboot for more than 36 hours now with this fix..
Please review the brcmfmac fix here https://patchwork.kernel.org/project/linux-wireless/patch/1499428893-30750-1-git-send-email-arend.vanspriel@broadcom.com/.

Also please consider that in line 6706 there is also a chech for action frame len size.
I dont know why the  code at line 6706 which is pretty much the same does not apply correctly and allow the crash to happen.
I havent removed it because its not exact the same command.
The first command returns an error the second command returns an error and terminate.